### PR TITLE
Add Ghizmo, a command line for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 + [git-stats, a GitHub-like contributions calendar, but locally, with all your git commits.](https://github.com/IonicaBizau/git-stats).
 + [Friction, a Github project linter](https://github.com/rafalchmiel/friction).
 + [Hub, makes git better with Github](https://hub.github.com).
++ [Ghizmo, a command line for GitHub](https://github.com/jlevy/ghizmo).
 + [GitFame, repository collaborators sorted by contributions](https://github.com/oleander/git-fame-rb).
 + [Github Changelog Generator](https://github.com/skywinder/github-changelog-generator). 
 


### PR DESCRIPTION
Thanks for the nice list!

Shameless promotion of a hack of my own that may be of interest:
[Ghizmo](https://github.com/jlevy/ghizmo) is a sort of missing command line for GitHub that gives access to _all_ the GitHub APIs (such as for contributors, pull requests, releases, etc., beyond what hub gives). Input and output via JSON, for compatibility with jq.

Would be glad for feedback, contributions, and/or considering it for merging in this list.
